### PR TITLE
CE-v9.0-P001: add shallow-depth razoring (d≤2)

### DIFF
--- a/PATCHES.md
+++ b/PATCHES.md
@@ -4,14 +4,23 @@ This repository uses chat-delivered patches tracked here. Each patch is identifi
 
 ## Index
 
-| ID           | Title                                          | Date (Europe/Paris) | Status    | Affected                     |
-|--------------|-------------------------------------------------|---------------------|-----------|------------------------------|
-| CE-v7.3-P001 | Introduce PATCHES.md and .editorconfig         | 2025-09-06          | APPLIED   | PATCHES.md, .editorconfig    |
-| CE-v7.3-P002 | Root PV/bestMove sanity checks (debug-only)    | 2025-09-06          | PROPOSED  | SearchFacade.java            |
-| CE-v8.0-P003 | LMP + History Pruning (non-PV, shallow)        | 2025-09-06          | PROPOSED  | SearchConfig.java, Negamax.java |
-| CE-v8.0-P004 | Soften LMP; disable HP by default; safety gates| 2025-09-06          | PROPOSED  | SearchConfig.java (defaults), Negamax.java |
+| ID           | Title                                           | Date (Europe/Paris) | Status   | Affected                                   |
+|--------------|-------------------------------------------------|---------------------|----------|--------------------------------------------|
+| CE-v9.0-P001 | Razoring at shallow depth (d≤2)                 | 2025-09-06          | PROPOSED | Negamax.java                               |
+| CE-v8.0-P004 | Soften LMP; disable HP by default; safety gates | 2025-09-06          | PROPOSED | SearchConfig.java (defaults), Negamax.java |
+| CE-v8.0-P003 | LMP + History Pruning (non-PV, shallow)         | 2025-09-06          | PROPOSED | SearchConfig.java, Negamax.java            |
+| CE-v7.3-P002 | Root PV/bestMove sanity checks (debug-only)     | 2025-09-06          | PROPOSED | SearchFacade.java                          |
+| CE-v7.3-P001 | Introduce PATCHES.md and .editorconfig          | 2025-09-06          | APPLIED  | PATCHES.md, .editorconfig                  |
 
 ---
+
+## CE-v9.0-P001
+- **Title:** Razoring at shallow depth (d≤2)
+- **Rationale:** Fast fail-low at depth 1–2 when static eval is well below α. Confirm with qsearch to avoid tactical misses.
+- **Risk:** Low. Guarded by mate margin, no-check, and king-danger.
+- **How to test:** Same opening set + TC. Expect speedup; no tactical regressions on standard suites.
+- **Dependencies:** None.
+- **Notes:** Margins (150/300) are conservative and can be tuned later.
 
 ## CE-v8.0-P004
 - **Title:** Soften LMP; disable HP by default; safety gates

--- a/backups/engines/fight_engines.ps1
+++ b/backups/engines/fight_engines.ps1
@@ -31,7 +31,7 @@ md $outputFolder -ea 0
   -openings file="$bookPath" format=pgn order=sequential plies=8 policy=round `
   -srand 123456 `
   -repeat `
-  -games 50 -concurrency 8 `
+  -games 50 -concurrency 6 `
   -recover `
   -ratinginterval 10 `
   -outcomeinterval 10 `


### PR DESCRIPTION
**What**
Add shallow-depth razoring in Negamax: when static eval is well below alpha at d≤2 (non-PV, not in check), verify with qsearch and return fail-low.

**Why**
Cuts obviously bad branches earlier, synergizing with futility/null-move. Guarded by mate margin and king-danger to avoid tactical harm.

**Details**
- Margins: 150 (d=1), 300 (d=2)
- Skips when in check, or in high king danger.

**Patch ID**
CE-v9.0-P001

**Risk**
Low, conservative.

**Testing**
Run the standard gauntlet vs v8.0 baseline; expect speedup and neutral-to-positive ELO.